### PR TITLE
Updated deps + Beams publish method deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 composer.phar
 composer.lock
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "neo/pusher-beams",
+    "name": "NextmediaMA/pusher-beams",
     "description": "Pusher Beams is a push notification service from Pusher.",
     "keywords": [
         "laravel",
@@ -11,10 +11,10 @@
         "neo"
     ],
     "license": "MIT",
-    "homepage": "https://github.com/neoighodaro/pusher-beams",
+    "homepage": "https://github.com/NextmediaMA/pusher-beams",
     "support": {
-        "issues": "https://github.com/neoighodaro/pusher-beams/issues",
-        "source": "https://github.com/neoighodaro/pusher-beams"
+        "issues": "https://github.com/NextmediaMA/pusher-beams/issues",
+        "source": "https://github.com/NextmediaMA/pusher-beams"
     },
     "authors": [
         {
@@ -24,11 +24,11 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/events": "5.5.* || 5.6.*",
-        "illuminate/notifications": "5.5.* || 5.6.*",
-        "illuminate/queue": "5.5.* || 5.6.*",
-        "illuminate/support": "5.5.* || 5.6.*",
-        "pusher/pusher-push-notifications": "^0.10.6"
+        "illuminate/events": "5.5.* || 5.6.* || 5.7.*",
+        "illuminate/notifications": "5.5.* || 5.6.* || 5.7.*",
+        "illuminate/queue": "5.5.* || 5.6.* || 5.7.*",
+        "illuminate/support": "5.5.* || 5.6.* || 5.7.*",
+        "pusher/pusher-push-notifications": "^1.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",

--- a/src/PusherBeams.php
+++ b/src/PusherBeams.php
@@ -49,7 +49,7 @@ class PusherBeams
         }
 
         try {
-            $response = $this->beams->publish(
+            $response = $this->beams->publishToInterests(
                 $interest,
                 $notification->toPushNotification($notifiable)->toArray()
             );


### PR DESCRIPTION
- Update Laravel and Pusher packages to last version
- Use `publishToInterests` method instead of `publish` (Removed)